### PR TITLE
chore: remove get all tokens balances

### DIFF
--- a/packages/plugin-bnb/src/templates/index.ts
+++ b/packages/plugin-bnb/src/templates/index.ts
@@ -7,7 +7,7 @@ export const getBalanceTemplate = `Given the recent messages and wallet informat
 Extract the following information about the requested check balance:
 - Chain to execute on. Must be one of ["bsc", "bscTestnet", "opBNB", "opBNBTestnet"]. Default is "bsc".
 - Address to check balance for. Optional, must be a valid Ethereum address starting with "0x" or a web3 domain name. If not provided, use the BNB chain Wallet Address.
-- Token symbol or address. Optional. The address must be a valid Ethereum address starting with "0x".
+- Token symbol or address. Could be a token symbol or address. If the address is provided, it must be a valid Ethereum address starting with "0x". Default is "BNB".
 If any field is not provided, use the default value. If no default value is specified, use null.
 
 Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined:
@@ -16,7 +16,7 @@ Respond with a JSON markdown block containing only the extracted values. Use nul
 {
     "chain": SUPPORTED_CHAINS,
     "address": string | null,
-    "token": string | null
+    "token": string
 }
 \`\`\`
 `;

--- a/packages/plugin-bnb/src/tests/getBalance.test.ts
+++ b/packages/plugin-bnb/src/tests/getBalance.test.ts
@@ -29,7 +29,7 @@ describe("GetBalance Action", () => {
                 token: "BNB",
             };
             const resp = await ga.getBalance(input);
-            console.log("BNB balance", resp.balances[0]);
+            console.log("BNB balance", resp.balance);
         });
 
         it("get USDC balance", async () => {
@@ -39,16 +39,20 @@ describe("GetBalance Action", () => {
                 token: "USDC",
             };
             const resp = await ga.getBalance(input);
-            console.log("USDC balance", resp.balances[0]);
+            console.log("USDC balance", resp.balance);
         });
 
-        it("get all token balances", async () => {
+        it("get balance by token contract address", async () => {
             const input: GetBalanceParams = {
                 chain: "bsc",
                 address: account.address,
+                token: "0x55d398326f99059ff775485246999027b3197955",
             };
             const resp = await ga.getBalance(input);
-            console.log("token balances", resp.balances);
-        }, 50000);
+            console.log(
+                "0x55d398326f99059ff775485246999027b3197955 balance",
+                resp.balance
+            );
+        });
     });
 });

--- a/packages/plugin-bnb/src/types/index.ts
+++ b/packages/plugin-bnb/src/types/index.ts
@@ -3,16 +3,11 @@ import type { Address, Hash } from "viem";
 export type SupportedChain = "bsc" | "bscTestnet" | "opBNB" | "opBNBTestnet";
 export type StakeAction = "deposit" | "withdraw" | "claim";
 
-export interface Balance {
-    token: string;
-    balance: string;
-}
-
 // Action parameters
 export interface GetBalanceParams {
     chain: SupportedChain;
     address?: Address;
-    token?: string;
+    token: string;
 }
 
 export interface TransferParams {
@@ -55,7 +50,7 @@ export interface FaucetParams {
 export interface GetBalanceResponse {
     chain: SupportedChain;
     address: Address;
-    balances: Balance[];
+    balance?: { token: string; amount: string };
 }
 
 export interface TransferResponse {


### PR DESCRIPTION
This pr is to remove support for getting all tokens balances in `getBalance` action as this is unstable and time-consuming.